### PR TITLE
Enabling GH actions to test py311 and py312

### DIFF
--- a/.github/workflows/python-tox.yml
+++ b/.github/workflows/python-tox.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.7", "3.8", "3.9", "3.10"]
+        python-version: ["3.7", "3.8", "3.9", "3.10", "3.11", "3.12"]
 
     steps:
     - uses: actions/checkout@v3

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py37,py38,py39,py310,py3.11,pre-commit
+envlist = py37,py38,py39,py310,py311,py312,pre-commit
 isolated_build = True
 
 [gh-actions]
@@ -14,6 +14,7 @@ python =
     3.9: py39,pre-commit
     3.10: py310
     3.11: py311
+    3.12: py312
 
 [testenv:pre-commit]
 skip_install = true


### PR DESCRIPTION
Currently testing in GH actions workflow doesn't go above python 3.10