### PR TITLE
Fix for deprecation warnings

### DIFF
--- a/src/gurobi_logtools/helpers.py
+++ b/src/gurobi_logtools/helpers.py
@@ -26,8 +26,8 @@ def fill_default_parameters(summary):
         if re_parameter_column.match(column) and series.isnull().any()
     ]
     # TODO test cases where there are different versions involved
-    return summary.groupby("Version", group_keys=False).apply(
-        partial(fill_for_version, parameter_columns=parameter_columns)
+    return summary.groupby("Version", group_keys=False)[summary.columns].apply(
+        partial(fill_for_version, parameter_columns=parameter_columns),
     )
 
 
@@ -44,7 +44,7 @@ def fill_for_version_nosuffix(group):
 
 def fill_default_parameters_nosuffix(parameters):
     """Fill defaults for Version and parameter cols with no (Parameter) suffix."""
-    return parameters.groupby("Version", group_keys=False).apply(
+    return parameters.groupby("Version", group_keys=False)[parameters.columns].apply(
         fill_for_version_nosuffix
     )
 

--- a/tests/test_fill_defaults.py
+++ b/tests/test_fill_defaults.py
@@ -1,5 +1,5 @@
 import pandas as pd
-from pandas.api.types import is_categorical_dtype, is_float_dtype, is_integer_dtype
+from pandas.api.types import is_float_dtype, is_integer_dtype
 from pandas.testing import assert_frame_equal
 
 import gurobi_logtools as glt
@@ -20,7 +20,7 @@ def test_parameter_values():
 def test_pretty_parameters():
     summary = glt.get_dataframe(["data/*.log"], prettyparams=True)
     presolve = summary["Presolve (Parameter)"]
-    assert is_categorical_dtype(presolve)
+    assert isinstance(presolve.dtype, pd.CategoricalDtype)
     assert set(presolve.unique()) == {
         "-1: Automatic",
         "1: Conservative",


### PR DESCRIPTION
We see some deprecation warnings under Pandas 2:

gurobi_logtools/helpers.py:29: DeprecationWarning: DataFrameGroupBy.apply operated on the grouping columns. This behavior is deprecated, and in a future version of pandas the grouping columns will be excluded from the operation. Either pass `include_groups=False` to exclude the groupings or explicitly select the grouping columns after groupby to silence this warning.

gurobi_logtools/helpers.py:47: DeprecationWarning: DataFrameGroupBy.apply operated on the grouping columns. This behavior is deprecated, and in a future version of pandas the grouping columns will be excluded from the operation. Either pass `include_groups=False` to exclude the groupings or explicitly select the grouping columns after groupby to silence this warning.

gurobi-logtools/tests/test_fill_defaults.py:23: DeprecationWarning: is_categorical_dtype is deprecated and will be removed in a future version. Use isinstance(dtype, pd.CategoricalDtype) instead