### PR TITLE
FileNotFoundError raised

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 ## Unreleased
 ### Fixed
 ### Changed
+- If logfiles are not found when parsing then a FileNotFoundError is raised
 ### Removed
 
 ## 3.1.0 - 2024-07-25

--- a/src/gurobi_logtools/api.py
+++ b/src/gurobi_logtools/api.py
@@ -169,8 +169,12 @@ def parse(patterns: Union[str, List[str]], write_to_dir=None) -> ParseResult:
     result = ParseResult(write_to_dir=write_to_dir)
     if type(patterns) is str:
         patterns = [patterns]
-    logfiles = itertools.chain(*(glob.glob(pattern) for pattern in patterns))
-    for logfile in sorted(set(logfiles)):
+    logfiles = sorted(
+        set(itertools.chain(*(glob.glob(pattern) for pattern in patterns)))
+    )
+    if not len(logfiles):
+        raise FileNotFoundError(f"No logfiles found in patterns: {patterns}")
+    for logfile in logfiles:
         result.parse(logfile)
     return result
 
@@ -190,8 +194,10 @@ def get_dataframe(logfiles: List[str], timelines=False, prettyparams=False):
     """
     result = parse(logfiles)
     summary = result.summary(prettyparams=prettyparams)
+
     if not timelines:
         return summary
+
     return summary, dict(
         norel=result.progress("norel"),
         rootlp=result.progress("rootlp"),

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -281,3 +281,8 @@ def test_rewrite_filenames():
             assert log_file.stem == expected_name
             assert len(start_lines) == 1
             assert len(end_lines) == 1
+
+
+def test_no_logfile_error():
+    with pytest.raises(FileNotFoundError):
+        glt.parse("/file/with/a/tyop")


### PR DESCRIPTION
### Checklist

- [x] closes #26 
- [x] tests added
- [x] tests passed
- [x] all linting tests pass
- [x] changelog entry

### Description:
If logfiles are not found when parsing then a FileNotFoundError is raised