### PR TITLE
test Python version in reverse chronological order

### DIFF
--- a/.github/workflows/python-tox.yml
+++ b/.github/workflows/python-tox.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12", "3.13"]
+        python-version: ["3.13", "3.12", "3.11", "3.10", "3.9"]
 
     steps:
     - uses: actions/checkout@v4

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,9 @@
 ### Fixed
 - fixed platform-specific issues in tests with file and path handling 
 ### Changed
+- test Python versions in reverse chronological order
 ### Removed
+- remove Python 3.8 tests
 
 ## 3.2.0 - 2024-12-19
 ### Fixed


### PR DESCRIPTION
### Checklist

- [ ] closes #xxxx
- [ ] tests passed
- [ ] all linting tests pass
- [ ] changelog entry

### Description:
This reverts the order of Python versions to be tested so we can detect version incompatibilities more easily, without tests failing right away because of an outdated Python version.