### PR TITLE
Using absolute paths in markdown files

### DIFF
--- a/Dashboard.md
+++ b/Dashboard.md
@@ -1,6 +1,6 @@
 # Gurobi-logtools plotting dashboard
 
-![dashboard map](assets/dashboard_map.svg)
+![dashboard map](https://github.com/Gurobi/gurobi-logtools/blob/master/assets/dashboard_map.svg)
 
 
 ## 1) x, y, color

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<img src="assets/logo_light_or_dark_mode.svg" justify-content="center">
+<img src="https://github.com/Gurobi/gurobi-logtools/blob/master/assets/logo_light_or_dark_mode.svg" justify-content="center">
 
 <p align="center">
 	<a href="https://pypi.python.org/pypi/gurobi-logtools" alt="PyPI">
@@ -16,7 +16,7 @@ With **gurobi-logtools**, you can extract information from Gurobi log files and 
 >
 > `import gurobi_logtools as glt`
 
-![performance plot](./assets/performance-plot.png)
+![performance plot](https://github.com/Gurobi/gurobi-logtools/blob/master/assets/performance-plot.png)
 
 # Installation
 


### PR DESCRIPTION
### Description:

Using absolute paths (to github assets) in markdown so images render on PyPI.